### PR TITLE
passing attributes instead of id for more custom hijacking

### DIFF
--- a/includes/class-dlm-shortcodes.php
+++ b/includes/class-dlm-shortcodes.php
@@ -79,7 +79,7 @@ class DLM_Shortcodes {
 		}
 
 		// Allow third party extensions to hijack shortcode
-		$hijacked_content = apply_filters( 'dlm_shortcode_download_content', '', $id );
+		$hijacked_content = apply_filters( 'dlm_shortcode_download_content', '', $atts );
 
 		// If there's hijacked content, return it and be done with it
 		if( '' !== $hijacked_content ) {

--- a/includes/class-dlm-shortcodes.php
+++ b/includes/class-dlm-shortcodes.php
@@ -79,7 +79,7 @@ class DLM_Shortcodes {
 		}
 
 		// Allow third party extensions to hijack shortcode
-		$hijacked_content = apply_filters( 'dlm_shortcode_download_content', '', $atts );
+		$hijacked_content = apply_filters( 'dlm_shortcode_download_content', '', $id, $atts );
 
 		// If there's hijacked content, return it and be done with it
 		if( '' !== $hijacked_content ) {


### PR DESCRIPTION
hey, great plugin.  I was doing a bit more advanced custom output for a [download] shortcode based on the version name to hack together personalized downloads for users (saving a username in the version name for a download).

I noticed you had a filter to override the generation of the download shortcode output, but only had access to the $id.  It would be great if this filter passed in the $attr object instead, so developers would be able to have access to all parameters passed via the shortcode (my usecase needed access to the version attribute).

what do you think?
