### PR TITLE
Fix version string escaping in DLM_Download::get_version_id()

### DIFF
--- a/includes/class-dlm-download.php
+++ b/includes/class-dlm-download.php
@@ -449,7 +449,12 @@ class DLM_Download {
 		$versions = $this->get_file_versions();
 
 		foreach ( $versions as $version_id => $version ) {
-			if ( ( is_numeric( $version->version ) && version_compare( $version->version, strtolower( $version_string ), '=' ) ) || strtolower( $version->version ) === strtolower( $version_string ) ) {
+			// Simulate result of version string escaping as would happen when
+			// generating download link in `dlm_download_get_the_download_link`
+			// filter and remove protocol added by the `esc_url_raw()`.
+			$url_compatible_version = str_replace('http://', '', esc_url_raw($version->version));
+
+			if ( ( is_numeric( $version->version ) && version_compare( $version->version, strtolower( $version_string ), '=' ) ) || strtolower( $url_compatible_version ) === strtolower( $version_string ) ) {
 				return $version_id;
 			}
 		}


### PR DESCRIPTION
Fixes version string escaping. Escaping happens when generating download link by `dlm_download_get_the_download_link` filter, but is missing when comparing version strings.

Fix: simulate result of version string escaping and removes protocol added by the `esc_url_raw()`.

Use case when `strtolower( $version->version ) === strtolower( $version_string )` fails:

```php
class DLM_Download {
    // [...]
    public function get_the_download_link() {
        // [...]  $link: 'http://example.com/download/123/?version=some text with spaces'

        return apply_filters( 'dlm_download_get_the_download_link', esc_url_raw( $link ), $this, $this->version_id );
        // esc_url_raw($link) >>> 'http://example.com/download/123/?version=sometextwithspaces'
    }

    // [...]

    public function get_version_id( $version_string = '' ) {
        // [...] $version_string from $_GET['version']: 'sometextwithspaces';

        foreach ( $versions as $version_id => $version ) {
            // $version->version: 'some text with spaces'
            // strtolower( $url_compatible_version ) === strtolower( $version_string ): false
        }
    }
}

```