### PR TITLE
Remove trailing space from downloads count

### DIFF
--- a/templates/content-download-filename.php
+++ b/templates/content-download-filename.php
@@ -10,6 +10,5 @@ global $dlm_download;
 	   printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_the_version_number() );
    } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
 	<?php $dlm_download->the_filename(); ?>
-	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?>
-	)
+	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?>)
 </a>

--- a/templates/content-download.php
+++ b/templates/content-download.php
@@ -9,6 +9,5 @@ global $dlm_download;
 	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_the_version_number() );
 } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
 	<?php $dlm_download->the_title(); ?>
-	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?>
-	)
+	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_the_download_count(), 'download-monitor' ), $dlm_download->get_the_download_count() ) ?>)
 </a>


### PR DESCRIPTION
In two of the default download templates, pretty code formatting
results in a trailing space between the download count and the closing
parenthesis. Remove the space.