### PR TITLE
Fix typo in dlm_upload(s) name for tip

### DIFF
--- a/includes/admin/class-dlm-admin-writepanels.php
+++ b/includes/admin/class-dlm-admin-writepanels.php
@@ -128,7 +128,7 @@ class DLM_Admin_Writepanels {
 		echo '<p class="form-field form-field-checkbox">
 			<input type="checkbox" name="_redirect_only" id="_redirect_only" ' . checked( get_post_meta( $thepostid, '_redirect_only', true ), 'yes', false ) . ' />
 			<label for="_redirect_only">' . __( 'Redirect to file', 'download-monitor' ) . '</label>
-			<span class="description">' . __( 'Don\'t force download. If the <code>dlm_upload</code> folder is protected you may need to move your file.', 'download-monitor' ) . '</span>
+			<span class="description">' . __( 'Don\'t force download. If the <code>dlm_uploads</code> folder is protected you may need to move your file.', 'download-monitor' ) . '</span>
 		</p>';
 
 		do_action( 'dlm_options_end', $thepostid );


### PR DESCRIPTION
This tip calls the uploads directory that is automatically created by
DLM "dlm_upload" when it is actually "dlm_uploads".