### PR TITLE
Valid call of trigger() in DLM_Download_Handler

### DIFF
--- a/includes/class-dlm-download-handler.php
+++ b/includes/class-dlm-download-handler.php
@@ -170,7 +170,7 @@ class DLM_Download_Handler {
 				if ( post_password_required( $download_id ) ) {
 					wp_die( get_the_password_form( $download_id ), __( 'Password Required', 'download-monitor' ) );
 				}
-				$this->trigger( $download, $version_id );
+				$this->trigger( $download );
 			} elseif ( $redirect = apply_filters( 'dlm_404_redirect', false ) ) {
 				wp_redirect( $redirect );
 			} else {


### PR DESCRIPTION
trigger() is a single parameter function. Fix the double parameter
call. The version_id information is contained in the $download
variable.