### PR TITLE
Apply double-counting log prevention to version_id

### DIFF
--- a/includes/class-dlm-download-handler.php
+++ b/includes/class-dlm-download-handler.php
@@ -186,6 +186,11 @@ class DLM_Download_Handler {
 	 */
 	private function log( $type = '', $status = '', $message = '', $download, $version ) {
 
+		// Prevent double logging
+		if ( ! empty( $_COOKIE['wp_dlm_downloading'] ) && $download->version_id == $_COOKIE['wp_dlm_downloading'] ) {
+			return;
+		}
+
 		// Logging object
 		$logging = new DLM_Logging();
 
@@ -241,7 +246,7 @@ class DLM_Download_Handler {
 			exit;
 		}
 
-		if ( empty( $_COOKIE['wp_dlm_downloading'] ) || $download->id != $_COOKIE['wp_dlm_downloading'] ) {
+		if ( empty( $_COOKIE['wp_dlm_downloading'] ) || $download->version_id != $_COOKIE['wp_dlm_downloading'] ) {
 			// Increase download count
 			$version->increase_download_count();
 
@@ -249,7 +254,7 @@ class DLM_Download_Handler {
 			do_action( 'dlm_downloading', $download, $version, $file_path );
 
 			// Set cookie to prevent double logging
-			setcookie( 'wp_dlm_downloading', $download->id, time() + 60, COOKIEPATH, COOKIE_DOMAIN, false, true );
+			setcookie( 'wp_dlm_downloading', $download->version_id, time() + 60, COOKIEPATH, COOKIE_DOMAIN, false, true );
 		}
 
 		// Redirect to the file...


### PR DESCRIPTION
The wp_dlm_downloading cookie currently does nothing. There is no
check in place to actually reference the value in the cookie and
prevent logging. Fix this in the log() function.

Distinct versions of the same download should still both log within
the 60sec timeout. Change the contents of the wp_dlm_downloading
cookie to version_id instead of the overall download id.