### PR TITLE
Log: Report missing versions for removed downloads

### DIFF
--- a/includes/admin/class-dlm-logging-list-table.php
+++ b/includes/admin/class-dlm-logging-list-table.php
@@ -109,7 +109,11 @@ class DLM_Logging_List_Table extends WP_List_Table {
 				}
 
 				if ( $log->version ) {
-					$download_string .= ' (' . sprintf( __( 'v%s', 'download-monitor' ), $log->version ) . ')';
+					if ( $download->version_exists( $log->version_id ) ) {
+						$download_string .= sprintf( __( ' (v%s)', 'download-monitor' ), $log->version );
+					} else {
+						$download_string .= sprintf( __( ' (v%s no longer exists)', 'download-monitor' ), $log->version );
+					}
 				}
 
 				return $download_string;
@@ -118,7 +122,7 @@ class DLM_Logging_List_Table extends WP_List_Table {
 				$download = new DLM_Download( $log->download_id );
 				$download->set_version( $log->version_id );
 
-				if ( $download->exists() && $download->get_the_filename() ) {
+				if ( $download->exists() && $download->version_exists( $log->version_id ) && $download->get_the_filename() ) {
 					$download_string = '<code>' . $download->get_the_filename() . '</code>';
 				} else {
 					$download_string = '&ndash;';


### PR DESCRIPTION
For old download versions which have since been deleted, the download
log currently fills-in the most recent version tag in the log line
instead of reporting the original version tag. Correct the log to
report the original version with a note that it no longer exists.