### PR TITLE
Allow passing post name to shortcodes and DLM_Download

### DIFF
--- a/includes/class-dlm-download.php
+++ b/includes/class-dlm-download.php
@@ -26,12 +26,29 @@ class DLM_Download {
 	 *
 	 * @access public
 	 *
-	 * @param int $id
+	 * @param mixed $id
 	 *
 	 */
 	public function __construct( $id ) {
-		$this->id         = absint( $id );
-		$this->post       = get_post( $this->id );
+		if ( is_array( $id ) ) {
+			// Allow passing full WP_Query arguments
+			$post_query = $id;
+		} else {
+			// If no query passed, assume id was passed
+			$post_query = array(
+				'p' => absint( $id )
+			);
+		}
+		$default_query = array(
+			'post_type' => 'dlm_download',
+			'numberposts' => 1,
+		);
+		$post_query = array_merge( $default_query, $post_query );
+		$posts = get_posts( $post_query );
+		if ( $posts ) {
+			$this->post = $posts[0];
+			$this->id = $posts[0]->id;
+		}
 		$this->version_id = ''; // Use latest current version
 	}
 

--- a/includes/class-dlm-shortcodes.php
+++ b/includes/class-dlm-shortcodes.php
@@ -69,6 +69,7 @@ class DLM_Shortcodes {
 
 		// extract shortcode atts
 		extract( shortcode_atts( array(
+			'name'       => '',
 			'id'         => '',
 			'autop'      => false,
 			'template'   => dlm_get_default_download_template(),
@@ -80,7 +81,11 @@ class DLM_Shortcodes {
 		$id = apply_filters( 'dlm_shortcode_download_id', $id );
 
 		// Check id
-		if ( empty( $id ) ) {
+		if ( !empty( $id ) ) {
+			$query = array( 'p' => $id );
+		} elseif ( !empty( $name ) ) {
+			$query = array( 'name' => $name );
+		} else {
 			return;
 		}
 
@@ -96,7 +101,7 @@ class DLM_Shortcodes {
 		$output = '';
 
 		// create download object
-		$download = new DLM_Download( $id );
+		$download = new DLM_Download( $query );
 
 		// check if download exists
 		if ( $download->exists() ) {
@@ -156,6 +161,7 @@ class DLM_Shortcodes {
 
 		extract( shortcode_atts( array(
 			'id'         => '',
+			'name'       => '',
 			'data'       => '',
 			'version_id' => '',
 			'version'    => ''
@@ -163,11 +169,19 @@ class DLM_Shortcodes {
 
 		$id = apply_filters( 'dlm_shortcode_download_id', $id );
 
-		if ( empty( $id ) || empty( $data ) ) {
+		if ( !empty( $id ) ) {
+			$query = array( 'p' => $id );
+		} elseif ( !empty( $name ) ) {
+			$query = array( 'name' => $name );
+		} else {
 			return;
 		}
 
-		$download = new DLM_Download( $id );
+		if ( empty( $data ) ) {
+			return;
+		}
+
+		$download = new DLM_Download( $query );
 
 		if ( ! empty( $version ) ) {
 			$version_id = $download->get_version_id( $version );
@@ -221,9 +235,9 @@ class DLM_Shortcodes {
 
 			// Taxonomies
 			case 'tags' :
-				return get_the_term_list( $id, 'dlm_download_tags', '', ', ', '' );
+				return get_the_term_list( $download->id, 'dlm_download_tags', '', ', ', '' );
 			case 'categories' :
-				return get_the_term_list( $id, 'dlm_download_category', '', ', ', '' );
+				return get_the_term_list( $download->id, 'dlm_download_category', '', ', ', '' );
 		}
 	}
 


### PR DESCRIPTION
I like using slugs instead of ID for things, a bit more user friendly.  Simple upgrade and backwards compatible.

The filters called by the shortcodes could be improved since calling
```
                $id = apply_filters( 'dlm_shortcode_download_id', $id );
```
when an $id isn't passed won't be very useful, perhaps tacking on the $atts as an additional argument would be the best course of action.