### PR TITLE
Add: `edit_download_link()` method

### DIFF
--- a/includes/class-dlm-download.php
+++ b/includes/class-dlm-download.php
@@ -472,6 +472,32 @@ class DLM_Download {
 	}
 
 	/**
+	 * Show the edit link
+	 *
+	 * @description Get the edit link to wp-admin to go straight to edit the page. For use in custom templates, where a developer might want to signpost admins from the frontend.
+	 * @access public
+	 * @return void
+	 */
+	public function edit_download_link( $text = null, $before = '', $after = '', $id = 0, $class = 'post-edit-link' ) {
+
+		if ($id===0) {
+			$id = $this->id;
+		}
+
+		if ( null === $text ) {
+			$text = __( 'Edit Download' );
+		}
+
+		edit_post_link(
+			$text,
+			$before,
+			$after,
+			$id,
+			$class
+		);
+	}
+	
+	/**
 	 * is_featured function.
 	 *
 	 * @access public


### PR DESCRIPTION
Add in method to use the `DLM_Download` object to output the wp-admin edit post link for that particular download. Can be used by developers in custom templates where they might want to signpost admins to the backend from the frontend.

# Detailed Description
I like to develop templates that allow my clients to use the front end to navigate just like a user would. When they see something that they need to edit, it is super useful to give them a "edit this" link that takes them straight to the right page in Wordpress, without having to search through lists in the backend. 

The WP Admin Bar does this well with the "Edit {post_type}" link. However in Download Monitor, where the front end display is so often done as a shortcode there is no "Edit Download" link. 

This method uses the Wordpress Core method: `edit_post_link()` but allows a developer to use the `$dlm_download` object when making their custom download templates.