### PR TITLE
Add setting which can allow downloads to be surfaced in site search. Also, make it so the permalink redirects to the download.

### DIFF
--- a/includes/admin/class-dlm-admin.php
+++ b/includes/admin/class-dlm-admin.php
@@ -178,6 +178,14 @@ class DLM_Admin {
 							'type'     => 'checkbox'
 						),
 						array(
+							'name'     => 'dlm_allow_x_forwarded_for',
+							'std'      => '0',
+							'label'    => __( 'Allow Proxy IP Override', 'download-monitor' ),
+							'cb_label' => __( 'Enable', 'download-monitor' ),
+							'desc'     => __( 'If enabled, Download Monitor will use the X_FORWARDED_FOR HTTP header set by proxies as the IP address. Note that anyone can set this header, making it less secure.', 'download-monitor' ),
+							'type'     => 'checkbox'
+						),
+						array(
 							'name'     => 'dlm_wp_search_enabled',
 							'std'      => '',
 							'label'    => __( 'Include in Search', 'download-monitor' ),

--- a/includes/admin/class-dlm-admin.php
+++ b/includes/admin/class-dlm-admin.php
@@ -182,7 +182,7 @@ class DLM_Admin {
 							'std'      => '',
 							'label'    => __( 'Include in Search', 'download-monitor' ),
 							'cb_label' => __( 'Enable', 'download-monitor' ),
-							'desc'     => __( 'If enabled, downloads will be included in the results made via a site search.', 'download-monitor' ),
+							'desc'     => __( 'If enabled, downloads will be included in the site\'s internal search results.', 'download-monitor' ),
 							'type'     => 'checkbox'
 						),
 					),

--- a/includes/admin/class-dlm-admin.php
+++ b/includes/admin/class-dlm-admin.php
@@ -177,6 +177,14 @@ class DLM_Admin {
 							'desc'     => __( 'If enabled, the download handler will check the PHP referer to see if it originated from your site and if not, redirect them to the homepage.', 'download-monitor' ),
 							'type'     => 'checkbox'
 						),
+						array(
+							'name'     => 'dlm_wp_search_enabled',
+							'std'      => '',
+							'label'    => __( 'Include in Search', 'download-monitor' ),
+							'cb_label' => __( 'Enable', 'download-monitor' ),
+							'desc'     => __( 'If enabled, downloads will be included in the results made via a site search.', 'download-monitor' ),
+							'type'     => 'checkbox'
+						),
 					),
 				),
 				'endpoints' => array(

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -24,10 +24,10 @@ class DLM_Post_Type_Manager {
 		}
 
 		// Check the Download Monitor setting/option for its download endpoint/URL/slug
-		if(get_option('dlm_download_endpoint_value') == 'ID'){
-			$rewrite = false;
+		if(get_option('dlm_download_endpoint_value') == 'slug'){
+			$rewrite = array( 'slug' => get_option('dlm_download_endpoint'));
 		}else{
-			$rewrite = array( 'slug' => get_option('dlm_download_endpoint_value'));
+			$rewrite = false;
 		}
 
 		// Register Download Post Type

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -25,7 +25,7 @@ class DLM_Post_Type_Manager {
 
 		// Check the Download Monitor setting/option for its download endpoint/URL/slug
 		if(get_option('dlm_download_endpoint_value') == 'slug'){
-			$rewrite = array( 'slug' => get_option('dlm_download_endpoint'));
+			$rewrite = array( 'slug' => get_option('dlm_download_endpoint').'-link'); // Append "-link" to slug to prevent conflict with the existing slug handling (would cause redirect loop if this matched exactly)
 		}else{
 			$rewrite = false;
 		}

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -67,7 +67,7 @@ class DLM_Post_Type_Manager {
 				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => $exclude_from_search,
 				'hierarchical'        => false,
-				'rewrite'             => true,
+				'rewrite'             => $rewrite,
 				'query_var'           => $publicly_visible,
 				'supports'            => apply_filters( 'dlm_cpt_dlm_download_supports', array(
 					'title',
@@ -105,7 +105,7 @@ class DLM_Post_Type_Manager {
 				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => true,
 				'hierarchical'        => false,
-				'rewrite'             => $rewrite,
+				'rewrite'             => false,
 				'query_var'           => $publicly_visible,
 				'show_in_nav_menus'   => false
 			) )

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -60,7 +60,7 @@ class DLM_Post_Type_Manager {
 				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => $exclude_from_search,
 				'hierarchical'        => false,
-				'rewrite'             => false,
+				'rewrite'             => true,
 				'query_var'           => $publicly_visible,
 				'supports'            => apply_filters( 'dlm_cpt_dlm_download_supports', array(
 					'title',
@@ -98,7 +98,7 @@ class DLM_Post_Type_Manager {
 				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => true,
 				'hierarchical'        => false,
-				'rewrite'             => false,
+				'rewrite'             => $rewrite,
 				'query_var'           => $publicly_visible,
 				'show_in_nav_menus'   => false
 			) )

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -23,6 +23,13 @@ class DLM_Post_Type_Manager {
 			$publicly_visible = false;
 		}
 
+		// Check the Download Monitor setting/option for its download endpoint/URL/slug
+		if(get_option('dlm_download_endpoint_value') == 'ID'){
+			$rewrite = false;
+		}else{
+			$rewrite = array( 'slug' => get_option('dlm_download_endpoint_value'));
+		}
+
 		// Register Download Post Type
 		register_post_type( "dlm_download",
 			apply_filters( 'dlm_cpt_dlm_download_args', array(

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -15,10 +15,12 @@ class DLM_Post_Type_Manager {
 	public function register() {
 
 		// Pull the setting for determining exclude_from_search value
-		if ( '1' == get_option( 'dlm_wp_search_enabled' ) ) { // They have chosen to make downloads show in WordPress search
+		if ( '1' == get_option( 'dlm_wp_search_enabled' ) ) { // They have chosen to make downloads show in WordPress search as well as being linked to directly
 			$exclude_from_search = false;
+			$publicly_visible = true;
 		} else {
 			$exclude_from_search = true;
+			$publicly_visible = false;
 		}
 
 		// Register Download Post Type
@@ -41,7 +43,7 @@ class DLM_Post_Type_Manager {
 					'parent'             => __( 'Parent Download', 'download-monitor' )
 				),
 				'description'         => __( 'This is where you can create and manage downloads for your site.', 'download-monitor' ),
-				'public'              => false,
+				'public'              => $publicly_visible,
 				'show_ui'             => true,
 				'capability_type'     => 'post',
 				'capabilities'        => array(
@@ -55,11 +57,11 @@ class DLM_Post_Type_Manager {
 					'delete_post'         => 'manage_downloads',
 					'read_post'           => 'manage_downloads'
 				),
-				'publicly_queryable'  => false,
+				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => $exclude_from_search,
 				'hierarchical'        => false,
 				'rewrite'             => false,
-				'query_var'           => false,
+				'query_var'           => $publicly_visible,
 				'supports'            => apply_filters( 'dlm_cpt_dlm_download_supports', array(
 					'title',
 					'editor',
@@ -75,13 +77,29 @@ class DLM_Post_Type_Manager {
 		// Register Download Version Post Type
 		register_post_type( "dlm_download_version",
 			apply_filters( 'dlm_cpt_dlm_download_version_args', array(
-				'public'              => false,
+				'labels'              => array(
+					'all_items'          => __( 'All Download Versions', 'download-monitor' ),
+					'name'               => __( 'Download Versions', 'download-monitor' ),
+					'singular_name'      => __( 'Download Version', 'download-monitor' ),
+					'add_new'            => __( 'Add New', 'download-monitor' ),
+					'add_new_item'       => __( 'Add Download Version', 'download-monitor' ),
+					'edit'               => __( 'Edit', 'download-monitor' ),
+					'edit_item'          => __( 'Edit Download Version', 'download-monitor' ),
+					'new_item'           => __( 'New Download Version', 'download-monitor' ),
+					'view'               => __( 'View Download Version', 'download-monitor' ),
+					'view_item'          => __( 'View Download Version', 'download-monitor' ),
+					'search_items'       => __( 'Search Download Versions', 'download-monitor' ),
+					'not_found'          => __( 'No Download Versions found', 'download-monitor' ),
+					'not_found_in_trash' => __( 'No Download Versions found in trash', 'download-monitor' ),
+					'parent'             => __( 'Parent Download Version', 'download-monitor' )
+				),
+				'public'              => $publicly_visible,
 				'show_ui'             => false,
-				'publicly_queryable'  => false,
+				'publicly_queryable'  => $publicly_visible,
 				'exclude_from_search' => true,
 				'hierarchical'        => false,
 				'rewrite'             => false,
-				'query_var'           => false,
+				'query_var'           => $publicly_visible,
 				'show_in_nav_menus'   => false
 			) )
 		);

--- a/includes/class-dlm-post-type-manager.php
+++ b/includes/class-dlm-post-type-manager.php
@@ -14,6 +14,13 @@ class DLM_Post_Type_Manager {
 	 */
 	public function register() {
 
+		// Pull the setting for determining exclude_from_search value
+		if ( '1' == get_option( 'dlm_wp_search_enabled' ) ) { // They have chosen to make downloads show in WordPress search
+			$exclude_from_search = false;
+		} else {
+			$exclude_from_search = true;
+		}
+
 		// Register Download Post Type
 		register_post_type( "dlm_download",
 			apply_filters( 'dlm_cpt_dlm_download_args', array(
@@ -49,7 +56,7 @@ class DLM_Post_Type_Manager {
 					'read_post'           => 'manage_downloads'
 				),
 				'publicly_queryable'  => false,
-				'exclude_from_search' => true,
+				'exclude_from_search' => $exclude_from_search,
 				'hierarchical'        => false,
 				'rewrite'             => false,
 				'query_var'           => false,

--- a/includes/download-functions.php
+++ b/includes/download-functions.php
@@ -13,3 +13,15 @@ function dlm_get_default_download_template() {
 
 	return $default;
 }
+
+// Filter the single_template with our custom function
+function dlm_download_single_post_type_template($single) {
+    global $wp_query, $post;
+    /* Checks for single template by post type */
+    if ($post->post_type == 'dlm_download' || $post->post_type == 'dlm_download_version'){
+        if(file_exists(plugin_dir_path(DLM_PLUGIN_FILE) . 'includes/download-query-var-redirect.php'))
+            return plugin_dir_path(DLM_PLUGIN_FILE) . 'includes/download-query-var-redirect.php';
+    }
+    return $single;
+}
+add_filter('single_template', 'dlm_download_single_post_type_template');

--- a/includes/download-query-var-redirect.php
+++ b/includes/download-query-var-redirect.php
@@ -1,0 +1,27 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly
+
+$download = new DLM_Download( get_the_id() );
+
+// check if download exists
+if ( $download->exists() ) {
+
+	// check if version is set
+	if ( ! empty( $version ) ) {
+		$version_id = $download->get_version_id( $version );
+	}
+
+	// check if version ID is set
+	if ( isset( $version_id ) && 0 != $version_id ) {
+		$download->set_version( $version_id );
+	}
+
+	$downloadURL = $download->get_the_download_link();
+
+}else{
+	$downloadURL = esc_url( home_url() ).'/not-found/';
+}
+
+wp_redirect($downloadURL);


### PR DESCRIPTION
I have a site which uses Algolia.com for its site search (though other site search setups would be affected as well!), and I wanted the downloads to be surfaced via that search. Currently (as of version 1.9.7), **the dlm_download post type is excluded from WordPress' site search without any way to change this**. As such, I've made it so there's now an option for enabling/disabling search visibility of downloads & made the resulting links go to the corresponding download URL.

# What was done
I've added an option to the Download settings page (a single checkbox under the general tab) which makes it possible to enable search for download on a site. This checkbox effectively toggles the `public`, `publicly_queryable`, `exclude_from_search`, and `query_var` values accordingly for the `dlm_download post type`. Then, I had to make it so there was a single post type template so I can act on the query_vars based on the download's permalink (which doesn't actually match the download's URL.) Finally, I made that single post type template use the query_vars to redirect to the correct download.

As an aside, I also went in and added labels to the `dlm_download_version` post type since many plugins which interface with the post types on a site show this as "Posts" as the fallback label, and that's confusing & simply incorrect (adding the labels was a minor change).

# Wrap-up
This functionality is important for a site I'm working on, and I imagine there's plenty of others out there that would love to have their site search able to return the downloads on their site (while keeping it as an option for those that don't).

I would love to see this added in a future release of the plugin so I don't have to worry about this important feature being removed when I update the plugin. Thanks for the great plugin!