### PR TITLE
Make sure get_version() is a valid function before trying to use it.

### DIFF
--- a/templates/content-download-box.php
+++ b/templates/content-download-box.php
@@ -23,11 +23,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php $dlm_download->the_excerpt(); ?>
 
-		<a class="download-button" title="<?php if ( $dlm_download->get_version()->has_version_number() ) {
+		<a class="download-button" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
 			printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
 		} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
 			<?php _e( 'Download File', 'download-monitor' ); ?>
+			<?php if( $dlm_download->get_version() ): ?>
 			<small><?php echo $dlm_download->get_version()->get_filename(); ?> &ndash; <?php echo $dlm_download->get_version()->get_filesize_formatted(); ?></small>
+			<?php else: ?>
+			<small><?php echo $dlm_download->the_title(); ?></small>
+			<?php endif; ?>
 		</a>
 
 	</div>

--- a/templates/content-download-filename.php
+++ b/templates/content-download-filename.php
@@ -9,9 +9,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var DLM_Download $dlm_download */
 ?>
-<a class="download-link" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
-	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
-} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-	<?php $dlm_download->the_title(); ?>
+<a class="download-link filetype-icon <?php if( $dlm_download->get_version() ) { echo 'filetype-' . $dlm_download->get_version()->get_filetype(); } ?>"
+   title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
+	   printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
+   } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
+	<?php if( $dlm_download->get_version() ): ?>
+	<?php echo $dlm_download->get_version()->get_filename(); ?>
+	<?php else: ?>
+	<small><?php echo $dlm_download->the_title(); ?></small>
+	<?php endif; ?>
 	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_download_count(), 'download-monitor' ), $dlm_download->get_download_count() ) ?>)
 </a>

--- a/templates/content-download-filename.php
+++ b/templates/content-download-filename.php
@@ -9,10 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var DLM_Download $dlm_download */
 ?>
-<a class="download-link filetype-icon <?php echo 'filetype-' . $dlm_download->get_version()->get_filetype(); ?>"
-   title="<?php if ( $dlm_download->get_version()->has_version_number() ) {
-	   printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
-   } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-	<?php echo $dlm_download->get_version()->get_filename(); ?>
+<a class="download-link" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
+	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
+} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
+	<?php $dlm_download->the_title(); ?>
 	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_download_count(), 'download-monitor' ), $dlm_download->get_download_count() ) ?>)
 </a>

--- a/templates/content-download-title.php
+++ b/templates/content-download-title.php
@@ -8,9 +8,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 /** @var DLM_Download $dlm_download */
-?>
-<a class="download-link" title="<?php if (  $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
+?><a class="download-link" title="<?php if (  $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
 	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
-} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-	<?php $dlm_download->the_title(); ?>
-</a>
+} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow"><?php $dlm_download->the_title(); ?></a>

--- a/templates/content-download-title.php
+++ b/templates/content-download-title.php
@@ -8,6 +8,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 /** @var DLM_Download $dlm_download */
-?><a class="download-link" title="<?php if (  $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
+?><a class="download-link" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
 	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
 } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow"><?php $dlm_download->the_title(); ?></a>

--- a/templates/content-download-title.php
+++ b/templates/content-download-title.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var DLM_Download $dlm_download */
 ?>
-<a class="download-link" title="<?php if ( $dlm_download->get_version()->has_version_number() ) {
+<a class="download-link" title="<?php if (  $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
 	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
 } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
 	<?php $dlm_download->the_title(); ?>

--- a/templates/content-download.php
+++ b/templates/content-download.php
@@ -8,10 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly
 
 /** @var DLM_Download $dlm_download */
-?>
-<a class="download-link" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
+?><a class="download-link" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
 	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
-} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
-	<?php $dlm_download->the_title(); ?>
-	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_download_count(), 'download-monitor' ), $dlm_download->get_download_count() ) ?>)
-</a>
+} ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow"><?php $dlm_download->the_title(); ?>
+	(<?php printf( _n( '1 download', '%d downloads', $dlm_download->get_download_count(), 'download-monitor' ), $dlm_download->get_download_count() ) ?>)</a>

--- a/templates/content-download.php
+++ b/templates/content-download.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /** @var DLM_Download $dlm_download */
 ?>
-<a class="download-link" title="<?php if ( $dlm_download->get_version()->has_version_number() ) {
+<a class="download-link" title="<?php if ( $dlm_download->get_version() && $dlm_download->get_version()->has_version_number() ) {
 	printf( __( 'Version %s', 'download-monitor' ), $dlm_download->get_version()->get_version_number() );
 } ?>" href="<?php $dlm_download->the_download_link(); ?>" rel="nofollow">
 	<?php $dlm_download->the_title(); ?>


### PR DESCRIPTION
I'm using Algolia for my site's search and it appears that the default template being used causes a 500 server error when Algolia is indexing the site (I have the site's search to include downloads). The 500 server error was caused by get_version() not being available at the time the downloads are indexed.

As a fix for this, I have it only try to display the version-specific info when the get_version function exists while providing a possible fallback when possible (leaving existing functionality untouched while fixing this server error).

I can confirm that Algolia can now index the site via its WordPress plugin without issue now (with this patch) and everything else is working as expected.