### PR TITLE
Remove post_content and post_excerpt fields from version updates

### DIFF
--- a/src/Version/WordPressVersionRepository.php
+++ b/src/Version/WordPressVersionRepository.php
@@ -167,8 +167,6 @@ class DLM_WordPress_Version_Repository implements DLM_Version_Repository {
 			// create
 			$version_id = wp_insert_post( array(
 				'post_title'   => $version->get_title(),
-				'post_content' => '',
-				'post_excerpt' => '',
 				'post_author'  => $version->get_author(),
 				'post_type'    => 'dlm_download_version',
 				'post_status'  => 'publish',
@@ -189,8 +187,6 @@ class DLM_WordPress_Version_Repository implements DLM_Version_Repository {
 			$version_id = wp_update_post( array(
 				'ID'           => $version->get_id(),
 				'post_title'   => $version->get_title(),
-				'post_content' => '',
-				'post_excerpt' => '',
 				'post_author'  => $version->get_author(),
 				'post_status'  => 'publish',
 				'post_parent'  => $version->get_download_id(),


### PR DESCRIPTION
I use the `post_content` and `post_excerpt` fields to store extra data about my downloads. Having both of these fields set to `''` inside the `wp_update_post()` function causes all of the data that I have stored there to get overridden and deleted whenever I add a new version to one of my downloads. Since it seems as if the plugin doesn't have an explicit need to use these fields, I've removed them from the function call.