### PR TITLE
Pass shortcode attributes to filters in shortcodes

### DIFF
--- a/src/Shortcodes.php
+++ b/src/Shortcodes.php
@@ -79,7 +79,7 @@ class DLM_Shortcodes {
 		), $atts ) );
 
 		// Make id filterable
-		$id = apply_filters( 'dlm_shortcode_download_id', $id );
+		$id = apply_filters( 'dlm_shortcode_download_id', $id, $atts );
 
 		// Check id
 		if ( empty( $id ) ) {
@@ -87,7 +87,7 @@ class DLM_Shortcodes {
 		}
 
 		// Allow third party extensions to hijack shortcode
-		$hijacked_content = apply_filters( 'dlm_shortcode_download_content', '', $id, $atts );
+		$hijacked_content = apply_filters( 'dlm_shortcode_download_content', '', $id, $atts, $content );
 
 		// If there's hijacked content, return it and be done with it
 		if ( '' !== $hijacked_content ) {
@@ -162,7 +162,7 @@ class DLM_Shortcodes {
 			'version'    => ''
 		), $atts ) );
 
-		$id = apply_filters( 'dlm_shortcode_download_id', $id );
+		$id = apply_filters( 'dlm_shortcode_download_id', $id, $atts );
 
 		if ( empty( $id ) || empty( $data ) ) {
 			return "";


### PR DESCRIPTION
This would allow similar behavior to what I proposed in #403 but in a method that doesn't change any default behavior.

Also passes $content to the 'dlm_shortcode_download_content' filter to better allow 3rd party extensions to hijack the shortcode. 