### PR TITLE
Add 'dlm_download_get_versions' filter

### DIFF
--- a/src/Download/Download.php
+++ b/src/Download/Download.php
@@ -500,7 +500,7 @@ class DLM_Download {
 			}
 		}
 
-		return $this->versions;
+		return apply_filters( 'dlm_download_get_versions', $this->versions, $this );
 	}
 
 	/**

--- a/src/Shortcodes.php
+++ b/src/Shortcodes.php
@@ -427,7 +427,7 @@ class DLM_Shortcodes {
 		ob_start();
 
 		// Allow filtering of arguments
-		$args = apply_filters( 'dlm_shortcode_downloads_args', $args );
+		$args = apply_filters( 'dlm_shortcode_downloads_args', $args, $atts );
 
 		$offset = $paginate ? ( max( 1, get_query_var( 'paged' ) ) - 1 ) * $per_page : $offset;
 


### PR DESCRIPTION
Allow filtering lists of versions returned.

Would be useful for allowing only specific file types to be returned (ie: requesting a pdf vs doc file).  Also would allow proper ordering of the list so the latest version can be compared based on version rather than most recently uploaded version.
