### PR TITLE
Minor compatibility fixes for PHP 7.4

### DIFF
--- a/src/DLM.php
+++ b/src/DLM.php
@@ -233,7 +233,7 @@ class WP_DLM {
 			$current_support = get_theme_support( 'post-thumbnails' );
 
 			// fix current support for some themes
-			if ( is_array( $current_support[0] ) ) {
+			if ( is_array( $current_support ) && is_array( $current_support[0] ) ) {
 				$current_support = $current_support[0];
 			}
 

--- a/src/DownloadHandler.php
+++ b/src/DownloadHandler.php
@@ -609,7 +609,7 @@ class DLM_Download_Handler {
 			@set_time_limit( 0 );
 		}
 
-		if ( function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() ) {
+		if ( version_compare( PHP_VERSION, '7.4.0', '<' ) && function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() ) {
 			@set_magic_quotes_runtime( 0 );
 		}
 


### PR DESCRIPTION
- Trying to access array offset on value of type bool in [/path/to]/wp-content/plugins/download-monitor/src/DLM.php on line 236

- Function get_magic_quotes_runtime() is deprecated in [/path/to]/wp-content/plugins/download-monitor/src/DownloadHandler.php on line 612

`get_magic_quotes_runtime` is marked as deprecated in PHP 7.4.0+: https://www.php.net/manual/en/function.get-magic-quotes-runtime.php

Fixes #620